### PR TITLE
TX2 integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+*.a
 *.o
+*.so
 *.dSYM
 *.csv
 *.out

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 GPU=1
-CUDNN=1
+CUDNN=0
 OPENCV=0
 OPENMP=0
 DEBUG=0
 
 ARCH= -gencode arch=compute_30,code=sm_30 \
       -gencode arch=compute_35,code=sm_35 \
-      -gencode arch=compute_50,code=[sm_50,compute_50] \
-      -gencode arch=compute_52,code=[sm_52,compute_52]
+      -gencode arch=compute_50,code=[sm_50,compute_50] 
+#      -gencode arch=compute_52,code=[sm_52,compute_52]
 #      -gencode arch=compute_20,code=[sm_20,sm_21] \ This one is deprecated?
 
 # This is what I use, uncomment if you know your arch and want to specify
@@ -26,7 +26,7 @@ ARFLAGS=rcs
 OPTS=-Ofast
 LDFLAGS= -lm -pthread 
 COMMON= -Iinclude/ -Isrc/
-CFLAGS=-Wall -Wno-unused-result -Wno-unknown-pragmas -Wfatal-errors -fPIC
+CFLAGS=-Wall -Wno-unused-result -Wno-unknown-pragmas -Wfatal-errors -fPIC -D_FORCE_INLINES
 
 ifeq ($(OPENMP), 1) 
 CFLAGS+= -fopenmp


### PR DESCRIPTION
Minor modifications for the TX2. Compute 52 isn't supported on the default CUDA (6.5). Also, gcc-4.8 is required so c++14 is not available. 6.5 CUDNN is unsupported by Darknet.